### PR TITLE
Update helm image to version 3_17_0

### DIFF
--- a/helm/Dockerfile
+++ b/helm/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
 
-ARG HELM_VERSION=v3.12.0
+ARG HELM_VERSION=v3.17.0
 ENV HELM_VERSION=$HELM_VERSION
 
 COPY kubectl.bash /builder/kubectl.bash

--- a/helm/README.md
+++ b/helm/README.md
@@ -41,7 +41,7 @@ To build this builder, run the following command in this directory.
 
 You can also build this builder setting `Helm` version via in `cloudbuild.yaml`, no need to do that in `Dockerfile` anymore.
 
-    args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v3.12.0', '.']
+    args: ['build', '--tag=gcr.io/$PROJECT_ID/helm', '--build-arg', 'HELM_VERSION=v3.17.0', '.']
 
 ## Using Helm
 

--- a/helm/cloudbuild.yaml
+++ b/helm/cloudbuild.yaml
@@ -6,4 +6,4 @@ images:
   - 'us-docker.pkg.dev/$PROJECT_ID/internal-tools/helm:latest'
 tags: [ 'cloud-builders-community' ]
 substitutions:
-  _HELM_VERSION: 3.12.0
+  _HELM_VERSION: 3.17.0


### PR DESCRIPTION
Should Fix Error:
```
Error: invalid argument "server" for "--dry-run" flag: strconv.ParseBool: parsing "server": invalid syntax
helm.go:84: [debug] invalid argument "server" for "--dry-run" flag: strconv.ParseBool: parsing "server": invalid syntax
```

Currently the helm binary version is `3.12.0` and does NOT support `--dry-run=server` only rendering locally.
[This feature was introduced in versions 3.13.3](https://github.com/bitnami/charts/issues/22834#issuecomment-1918930415)